### PR TITLE
fix grok-implementer permission-mode from acceptEdits to auto

### DIFF
--- a/agents/grok-implementer.md
+++ b/agents/grok-implementer.md
@@ -54,7 +54,7 @@ T=$(command -v gtimeout || command -v timeout || true)
 
 ${T:+$T 600} grok --prompt-file "$SPEC" \
   -m grok-4.5 \
-  --permission-mode acceptEdits \
+  --permission-mode auto \
   --output-format plain \
   --cwd "$(pwd)" \
   > /tmp/grok-final-$$.txt 2>&1


### PR DESCRIPTION
## Summary
- Grok CLI 0.2.93 does not auto-approve write tool calls with `--permission-mode acceptEdits`, causing writes to be canceled
- Falls back to `--permission-mode auto`, which works

## Test plan
- [x] Ran grok-implementer with `--permission-mode auto` and confirmed writes succeed