### PR TITLE
grok-implementer: fix two headless-lane footguns (preflight false negative, silent exec cancel)

### DIFF
--- a/agents/grok-implementer.md
+++ b/agents/grok-implementer.md
@@ -17,7 +17,11 @@ First action, always:
 command -v grok && grok --version && grok models 2>&1 | head -2
 ```
 
-`grok models` prints the login state and default model. If grok is not installed or not authenticated, **stop immediately** and return:
+`grok models` prints the login state and default model.
+
+**"You are not authenticated" is usually a false negative — retry once before giving up.** grok.com access tokens are short-lived (~6h); when one has lapsed, `grok models` prints "You are not authenticated" even though that same invocation silently refreshes the token in the background, so an immediate second call succeeds. If the first check reports not authenticated, run `grok models 2>&1 | head -2` once more. Only two consecutive "not authenticated" results mean a real logout.
+
+If grok is not installed, or both auth checks fail, **stop immediately** and return:
 
 ```
 GROK REPORT
@@ -55,6 +59,7 @@ T=$(command -v gtimeout || command -v timeout || true)
 ${T:+$T 600} grok --prompt-file "$SPEC" \
   -m grok-4.5 \
   --permission-mode acceptEdits \
+  --allow 'Bash(*)' \
   --output-format plain \
   --cwd "$(pwd)" \
   > /tmp/grok-final-$$.txt 2>&1
@@ -67,14 +72,15 @@ Flag discipline (non-negotiable):
 |---|---|
 | `--prompt-file "$SPEC"` | Headless single-task run from a file. No quoting hazards, no truncated specs. |
 | `-m grok-4.5` | The lane's producer is Grok 4.5, pinned explicitly — never rely on the CLI default. |
-| `--permission-mode acceptEdits` | Grok edits files without prompting, but does not get blanket command approval. Never `--always-approve` — you re-run verification yourself. |
+| `--permission-mode acceptEdits` | Grok edits files without prompting. Never `--always-approve` — you re-run verification yourself. |
+| `--allow 'Bash(*)'` | Required for headless runs. The Grok CLI merges the caller's global `~/.claude/settings.json` permission rules into its own resolver, and under that merge terminal-command execution defaults to "ask" — which with no human present silently cancels the turn (exit 0, no diff, no error) instead of failing loudly. The scoped allow approves shell execution only; it is not blanket auto-approval. |
 | `--cwd "$(pwd)"` | Deterministic working root. |
 | `--output-format plain` | Final message to stdout, captured for the report. |
 | `${T:+$T 600}` | Ten-minute wall clock when `timeout`/`gtimeout` exists. On timeout, report `STATUS: timeout` with whatever landed. |
 
 `-m grok-4.5` is the current top Grok tier — if the caller's spec names a different grok model, use that instead; the slug is a documented default, not a constant.
 
-3. **Verify independently.** Read the diff (`git diff` / `git status`), run the spec's verification command yourself, and read grok's final message from `"$FINAL"`. Grok's claim of success is not evidence; your re-run is. (`acceptEdits` may have blocked grok from running the verification itself — your re-run covers that by design.)
+3. **Verify independently.** Read the diff (`git diff` / `git status`), run the spec's verification command yourself, and read grok's final message from `"$FINAL"`. Grok's claim of success is not evidence; your re-run is.
 
 ## What you return
 


### PR DESCRIPTION
Two failure modes hit in production use of the `grok-implementer` lane, both costing a full turn each time. Diagnosed 2026-07-16/18 from the Grok CLI's own `~/.grok/logs/unified.jsonl` and `--debug` output; both are now also documented as operator runbook rules in the reporting workspace's `CLAUDE.md`.

## 1. Preflight false negative: `grok models` says "You are not authenticated" while auth is fine

grok.com access tokens are short-lived (~6h). When one has lapsed, `grok models` prints **"You are not authenticated"** even though that same invocation silently refreshes the token successfully. Caught in the CLI's unified log (grok 0.2.101): the same pid logged `auth.refresh.success` at `21:49:51.403Z` yet printed "not authenticated" at `.663Z`. An immediate second call succeeds.

The preflight as written treats one failed check as fatal, so the lane reports `STATUS: unavailable` and the caller falls back to a more expensive lane — precisely the routing this agent exists to avoid.

**Fix:** retry `grok models` once; only two consecutive failures mean a real logout.

## 2. Silent no-op: headless runs exit 0 with no files when grok needs a shell command

The Grok CLI merges the caller's global `~/.claude/settings.json` permission rules into its own resolver. Under that merge, terminal-command execution defaults to **"ask"** — and with no human present, an "ask" silently cancels the turn: exit 0, no diff, no error. Any spec step that needs even a trivial shell command (`ls`) kills the run invisibly. Two invocations were lost to this before `--debug` surfaced the cancel.

**Fix:** add a scoped `--allow 'Bash(*)'` to the documented invocation. This approves shell execution only — `--always-approve` remains forbidden, and the wrapper still re-runs verification itself (the stale parenthetical claiming `acceptEdits` may have blocked grok's own verification is removed, since it no longer applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)