### PR TITLE
fix: resolve escalation-trigger contradiction + drop unused tools in codex-implementer

### DIFF
--- a/agents/codex-implementer.md
+++ b/agents/codex-implementer.md
@@ -2,7 +2,7 @@
 name: codex-implementer
 description: Default implementation lane running GPT-5.6 Sol via the OpenAI Codex CLI (`codex exec`, reasoning effort high). Route routine, well-specified work here — the spec fully determines the outcome and Codex does the typing at a fraction of the architect's token cost, from a different model family than the session. Receives the standard five-part spec; drives codex to write the code; returns a structured report with verification evidence. Requires the `codex` CLI installed and authenticated — reports a structured error if it is missing, never silently substitutes itself.
 model: sonnet
-tools: Bash, Read, Grep, Glob
+tools: Bash, Read
 ---
 
 # Codex Implementer

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -24,7 +24,7 @@ What stays with the architect regardless of cost: decomposition, interface desig
 | Lane | Producer | Invoke | Route here when |
 |---|---|---|---|
 | Routine | GPT-5.6 Sol (high reasoning) | `codex-implementer` agent | The spec fully determines the outcome: boilerplate, wiring, CRUD, mechanical edits, straightforward features. **Default lane.** Requires the codex CLI. |
-| High-complexity | Fable 5 | `fable-implementer` agent | The outcome depends heavily on judgment the spec can't capture: subtle concurrency, non-trivial algorithms, security-sensitive paths, hard debugging, wide-blast-radius refactors — or the routine lane has already failed the task once. One-off escalations, never the default. |
+| High-complexity | Fable 5 | `fable-implementer` agent | The outcome depends heavily on judgment the spec can't capture: subtle concurrency, non-trivial algorithms, security-sensitive paths, hard debugging, wide-blast-radius refactors — or the routine lane has already failed the task twice. One-off escalations, never the default. |
 | Review | Fable 5 | `fable-advisor` agent | Not an implementation lane. Commitment boundaries and the mandatory end-of-deliverable review — see below. |
 
 Deciding rule: how much does the outcome depend on judgment the spec can't capture? Little → the default codex lane; you will verify anyway. A lot, and mistakes are costly → escalate to `fable-implementer`, or keep that piece with the architect. A routine-lane task that fails its spec once gets a corrected spec; twice, it escalates to Fable — repetition is evidence the task was misclassified.


### PR DESCRIPTION
Two small correctness fixes found while auditing the plugin's NL artifacts.

**1. `skills/orchestration/SKILL.md` contradicts itself on the escalation trigger.**
The lane table (line 27) says the routine lane escalates to Fable after failing **once**, but the deciding rule right below it (line 30) says *"fails its spec once gets a corrected spec; **twice**, it escalates"* — and `agents/fable-advisor.md:16` ("failed **twice**") and line 57 ("**two** distinct attempts") both agree on twice. Changed line 27 to match:

```diff
-— or the routine lane has already failed the task once. One-off escalations, never the default.
+— or the routine lane has already failed the task twice. One-off escalations, never the default.
```

**2. `agents/codex-implementer.md` declares tools it never uses.**
Frontmatter is `tools: Bash, Read, Grep, Glob`, but the body delegates all codebase exploration to the external `codex` CLI and only ever uses `Bash` (git/codex) and `Read`. Dropped the unused grants → `tools: Bash, Read` (least-privilege).

Everything else in the plugin checked clean (manifests, the other agents, model routing). Separately opening an issue about `<example>`-block coverage on the agents, since that's more of a suggestion than a mechanical fix.
